### PR TITLE
Custom Display Attributes

### DIFF
--- a/config/sudosu.php
+++ b/config/sudosu.php
@@ -14,8 +14,8 @@ return [
     | .local, simply add it to the arrow below.
     |
      */
-    
-    'allowed_tlds' => ['dev', 'local'],
+
+    'allowed_tlds'      => ['dev', 'local'],
 
     /*
     |--------------------------------------------------------------------------
@@ -26,7 +26,17 @@ return [
     | displayed in the select dropdown. This must be an Eloquent Model instance.
     |
      */
-    
-    'user_model' => App\User::class
-    
+
+    'user_model'        => App\User::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Display attribute
+    |--------------------------------------------------------------------------
+    |
+    | Field of the User model that is displayed in the dropdown.
+    |
+     */
+    'display_attribute' => 'name',
+
 ];

--- a/resources/views/user-selector.blade.php
+++ b/resources/views/user-selector.blade.php
@@ -5,19 +5,19 @@
     <div class="sudoSu__btn {{ $hasSudoed ? 'sudoSu__btn--hasSudoed' : '' }}" id="sudosu-js-btn">
         <i class="fa fa-user-secret" aria-hidden="true"></i>
     </div>
-    
+
     <div class="sudoSu__interface {{ $hasSudoed ? 'sudoSu__interface--hasSudoed' : '' }} hidden" id="sudosu-js-interface">
         @if ($hasSudoed)
             <div class="sudoSu__infoLine">
                 You are using account: <span>{{ $currentUser->name }}</span>
             </div>
-            
+
             @if ($originalUser)
                 <div class="sudoSu__infoLine">
                     You are logged in as: <span>{{ $originalUser->name }}</span>
                 </div>
             @endif
-            
+
             <form action="{{ route('sudosu.logout') }}" method="post">
                 {!! csrf_field() !!}
                 <input type="submit" class="sudoSu__resetBtn" value="{{ $originalUser ? 'Return to original user' : 'Log out' }}">
@@ -29,10 +29,10 @@
                 <option disabled selected>Sudo Su</option>
 
                 @foreach ($users as $user)
-                    <option value="{{ $user->id }}">{{ $user->name }}</option>
+                    <option value="{{ $user->id }}">{{ $user[config('sudosu.display_attribute', 'name')] }}</option>
                 @endforeach
             </select>
-            
+
             {!! csrf_field() !!}
 
             <input type="hidden" name="originalUserId" value="{{ $originalUser->id ?? null }}">


### PR DESCRIPTION
It was for me not clear which role a user has. This PR makes it possible to overwrite the default name that's display in the select-form. In my case I created an attribute in my User model and referred to that one instead of the name. 

```
public function getSudosuAttribute()
    {
        return implode(' ', [$this->name, $this->role->group]);
    }
```