### PR TITLE
Load CSS with asset() helper

### DIFF
--- a/resources/views/user-selector.blade.php
+++ b/resources/views/user-selector.blade.php
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
-<link rel="stylesheet" href="/sudo-su/css/app.css">
+<link rel="stylesheet" href="{{ asset('sudo-su/css/app.css') }}">
 
 <div class="sudoSu">
     <div class="sudoSu__btn {{ $hasSudoed ? 'sudoSu__btn--hasSudoed' : '' }}" id="sudosu-js-btn">


### PR DESCRIPTION
Fixes CSS not found when web root != '/'